### PR TITLE
Prevent errors when scoring wave reportType 1

### DIFF
--- a/docTemplates/asp08/index.js
+++ b/docTemplates/asp08/index.js
@@ -108,11 +108,13 @@ exports.parameters = (
     const waveResult = testData.wave.result.categories;
     const waveItems = [];
     ['error', 'contrast', 'alert'].forEach(category => {
-      waveItems.push(
-        ... Object
-        .entries(waveResult[category].items)
-        .map(entry => `<li>${category}/${entry[0]}: ${entry[1].description}</li>`)
-      );
+      if (waveResult[category].items) {
+        waveItems.push(
+          ... Object
+          .entries(waveResult[category].items)
+          .map(entry => `<li>${category}/${entry[0]}: ${entry[1].description}</li>`)
+        );
+      }
     });
     const waveFailures = waveItems.join(innerJoiner);
     paramData.waveResult = packageFailText(deficit.wave, 'wave', waveFailures);

--- a/procs/score/asp08.js
+++ b/procs/score/asp08.js
@@ -212,14 +212,16 @@ exports.scorer = acts => {
             rules.wave = 'multiply alerts by 2, contrast errors by 3, errors by 4; sum; subtract discounts';
             let totalDiscount = 0;
             ['error', 'contrast', 'alert'].forEach(level => {
-              const items = facts[level].items;
-              const waveRules = Object.keys(items);
-              waveRules.forEach(rule => {
-                const ruleDiscount = ruleDiscounts.wave[rule] * items[rule].count;
-                if (ruleDiscount) {
-                  totalDiscount += ruleDiscount;
-                }
-              });
+              if (facts[level].items) {
+                const items = facts[level].items;
+                const waveRules = Object.keys(items);
+                waveRules.forEach(rule => {
+                  const ruleDiscount = ruleDiscounts.wave[rule] * items[rule].count;
+                  if (ruleDiscount) {
+                    totalDiscount += ruleDiscount;
+                  }
+                });
+              }
             });
             deficit.wave
               = 2 * facts.alert.count


### PR DESCRIPTION
This PR fixes an issue when running the `wave` test with `reportType: 1` with the "Autotest score proc 8" conf.

When `reportType: 1` is used, each WAVE result category does not include the `items` object. This causes a `TypeError: Cannot convert undefined or null to object` error when calling `Object.keys()` or `Object.entries()` in 2 places:
- when computing discounts in the asp08.js scorer
- when listing issues in the asp08/index.js report generator

I'm happy to also apply this to other scorers and reports e.g a11y07 if this would be useful.